### PR TITLE
Please make the build reproducible.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,6 +149,7 @@ def list_message_files(package='wammu', suffix='.po'):
         _locale = os.path.basename(os.path.dirname(_file))
         _list.append((_locale, _file, os.path.join(
             'share', 'locale', _locale, 'LC_MESSAGES', '%s.mo' % package)))
+    _list.sort()
     return _list
 
 


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that wammu could not be built reproducibly as it iterates over
the filesystem in a non-deterministic order.

[0] https://reproducible-builds.org/